### PR TITLE
Fix bug for enable_torque and disable_torque command packets

### DIFF
--- a/lx16a.py
+++ b/lx16a.py
@@ -373,12 +373,12 @@ class LX16A:
         self._motor_mode = False
 
     def enable_torque(self) -> None:
-        packet = [self._id, 4, 31, 0]
+        packet = [self._id, 4, 31, 1]
         LX16A._send_packet(packet)
         self._torque_enabled = True
 
     def disable_torque(self) -> None:
-        packet = [self._id, 4, 31, 1]
+        packet = [self._id, 4, 31, 0]
         LX16A._send_packet(packet)
         self._torque_enabled = False
 


### PR DESCRIPTION
Parameter in `enable_torque` and `disable_torque` functions were swapped causing them to have opposite functionalities. Calling `enable_torque` caused the torque to be disabled, and calling `disable_torque` caused the torque to be enabled.

**From the LewanSoul Bus Servo Communication Protocol:**
Command name: SERVO_LOAD_OR_UNLOAD_WRITE
Command value: 31 Length: 4
Parameter 1: Whether the internal motor of the servo is unloaded power-downor not, the range 0 or 1, 0 represents the unloading power down, and the servo has no torque output. 1 represents the loaded motor, then the servo has atorque output, the default value is 0

